### PR TITLE
[fix] fix home-timeline with default params

### DIFF
--- a/server/lib/model_utils/messages.py
+++ b/server/lib/model_utils/messages.py
@@ -38,15 +38,15 @@ def get_recent_messages(count: int, offset: int, start_time: str, user_id: str):
 def get_timeline_messages(user_id: str, from_id: str=0, count: int=10):
     session = db.get_session()
     try:
-        from_id_db = f'{user_id}-{from_id}'
         messages = session.query(Tweet, TwitterUser) \
             .join(TwitterUser, and_(Tweet.user_id == TwitterUser.user_id, Tweet.client == TwitterUser.client))
         if from_id:
+            from_id_db = f'{user_id}-{from_id}'
             messages = messages.filter(Tweet.neotter_user_id == user_id, Tweet.message_id > from_id_db) \
-                .order_by(Tweet.created_datetime).limit(count)
+                .order_by(Tweet.created_datetime).limit(count).all()
         else:
-            messages = messages.filter(Tweet.neotter_user_id == user_id) \
-                .order_by(desc(Tweet.created_datetime)).limit(count)
+            messages = reversed(messages.filter(Tweet.neotter_user_id == user_id) \
+                .order_by(desc(Tweet.created_datetime)).limit(count).all())
     except (OperationalError, InternalError):
         logger.error(traceback.format_exc())
     finally:

--- a/test/server/api/v2/test_home_timeline.py
+++ b/test/server/api/v2/test_home_timeline.py
@@ -48,20 +48,11 @@ class TestHomeTimeline(unittest.TestCase):
                 .replace(tzinfo=TIMEZONE_UTC)
             self.assertLessEqual(abs(expected_expiration - got_expiration), datetime.timedelta(minutes=1))
 
-    def test_home_timeline(self):
-        count = 3
-        from_id = 1002
+    def _test_home_timeline(self, params: dict, expected: dict):
+        count = params['count']
+        from_id = params['from_id']
         table_name = 'neotter_users'
         results = {}
-        expected = {
-            '01': [
-                fixture.response_from_fixture(self.tweets['01'][2], version='v2'),
-                fixture.response_from_fixture(self.tweets['01'][3], version='v2')
-            ],
-            '02': [
-                fixture.response_from_fixture(self.tweets['02'][1], version='v2')
-            ]
-        }
         for user in self.db_data[table_name]:
             user_token = user['token']
             n_user = neotter_user.get_by_token(user_token)
@@ -76,3 +67,35 @@ class TestHomeTimeline(unittest.TestCase):
             expected_data = expected[user['id']]
             self.assertEqual(parsed, expected_data)
         print(json.dumps(results, ensure_ascii=False, indent=4))
+
+    def test_home_timeline(self):
+        params_1 = {
+            'count': 2,
+            'from_id': 1002
+        }
+        expected_1 = {
+            '01': [
+                fixture.response_from_fixture(self.tweets['01'][2], version='v2'),
+                fixture.response_from_fixture(self.tweets['01'][3], version='v2')
+            ],
+            '02': [
+                fixture.response_from_fixture(self.tweets['02'][1], version='v2')
+            ]
+        }
+        self._test_home_timeline(params_1, expected_1)
+
+        params_2 = {
+            'count': 2,
+            'from_id': 0
+        }
+        expected_2 = {
+            '01': [
+                fixture.response_from_fixture(self.tweets['01'][2], version='v2'),
+                fixture.response_from_fixture(self.tweets['01'][3], version='v2')
+            ],
+            '02': [
+                fixture.response_from_fixture(self.tweets['02'][0], version='v2'),
+                fixture.response_from_fixture(self.tweets['02'][1], version='v2'),
+            ]
+        }
+        self._test_home_timeline(params_2, expected_2)


### PR DESCRIPTION
home-timelineにfrom_idパラメータなしで投げた場合、想定の逆順でレスポンスが返ってくる問題を修正